### PR TITLE
Fix pandas append usage in backtest engine

### DIFF
--- a/src/backtest/backtest_engine.py
+++ b/src/backtest/backtest_engine.py
@@ -708,6 +708,7 @@ class BacktestEngine:
         }, name='OVERALL')
         
         # Append overall statistics
-        stats_df = stats_df.append(overall)
+        # pd.DataFrame.append was removed in pandas 2.0; use concat instead
+        stats_df = pd.concat([stats_df, overall.to_frame().T])
         
         return stats_df 


### PR DESCRIPTION
## Summary
- fix deprecated DataFrame.append usage in BacktestEngine

## Testing
- `python3 -m pytest --version` *(fails: No module named pytest)*